### PR TITLE
Add canute-ui to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ store.dispatch({ 'type': 'DECREMENT' })
 
 [urwid_todos](https://github.com/usrlocalben/urwid_todos) is a reimplementation of the Redux [todos](http://redux.js.org/docs/basics/ExampleTodoList.html) example made with [urwid_pydux](https://github.com/usrlocalben/urwid_pydux).
 
+[canute-ui}(https://github.com/Bristol-Braille/canute-ui) is the user interface for a multi-line electronic Braille e-book reader.
+
+
 ##### Acknowledgements
 
 The initial test suite was imported from [python-redux](https://github.com/ebrakke/python-redux), a Redux implementation for Python 3.4+.


### PR DESCRIPTION
I have now merged https://github.com/Bristol-Braille/canute-ui/pull/27 so Pydux will ship as part of the UI of our 3 prototypes going out to Braille users before Christmas. Right now it just has feature parity with our old version, and the code is still a bit rough, but in the future the use of Pydux should enable us to implement ideas to offer much more pleasant user interactions.

Thanks very much for your work!