### PR TITLE
Wrap log_middleware print statement in parens for python3 compatibility

### DIFF
--- a/pydux/log_middleware.py
+++ b/pydux/log_middleware.py
@@ -7,7 +7,7 @@ def log_middleware(store):
     """log all actions to console as they are dispatched"""
     def wrapper(next_):
         def log_dispatch(action):
-            print 'Dispatch Action:', action
+            print('Dispatch Action:', action)
             return next_(action)
         return log_dispatch
     return wrapper

--- a/pydux/log_middleware.py
+++ b/pydux/log_middleware.py
@@ -1,7 +1,7 @@
+from __future__ import print_function
 """
 logging middleware example
 """
-
 
 def log_middleware(store):
     """log all actions to console as they are dispatched"""


### PR DESCRIPTION
Another quick Python 3 compatibility tweak 