### PR TITLE
Add thunk middleware test

### DIFF
--- a/test/helpers/action_creators.py
+++ b/test/helpers/action_creators.py
@@ -10,7 +10,7 @@ def add_todo(text):
 def add_todo_if_empty(text):
     def anon(dispatch, get_state):
         if len(get_state()) == 0:
-            add_todo(text)
+            dispatch(add_todo(text))
     return anon
 
 def dispatch_in_middle(bound_dispatch_fn):

--- a/test/test_apply_middleware.py
+++ b/test/test_apply_middleware.py
@@ -32,5 +32,31 @@ class TestApplyMiddleware(unittest.TestCase):
                          [dict(id=1, text='Use Redux'), dict(id=2, text='Flux FTW!')])
 
 
+    def test_works_with_thunk_middleware(self):
+        store = apply_middleware(thunk)(create_store)(reducers['todos'])
+
+        store.dispatch(add_todo_if_empty('Hello'))
+        self.assertEqual(store['get_state'](), [
+            {
+                'id': 1,
+                'text': 'Hello'
+            }
+        ])
+
+        store['dispatch'](add_todo('World'))
+        self.assertEqual(store['get_state'](), [
+            {
+                'id': 1,
+                'text': 'Hello'
+            },
+            {
+                'id': 2,
+                'text': 'World'
+            }
+        ])
+
+        ##TODO: add_todo_async
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fails on the first assertion: thunk middleware isn't being properly applied. What do you think about adding an async action creator? Can it be done while maintaining support for both python 2 and 3? 